### PR TITLE
Enable stateless mode for StreamableHTTPHandler

### DIFF
--- a/main.go
+++ b/main.go
@@ -154,7 +154,7 @@ func main() {
 
 		handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 			return srv
-		}, &mcp.StreamableHTTPOptions{})
+		}, &mcp.StreamableHTTPOptions{Stateless: true})
 
 		// Start the server
 		if err := http.ListenAndServe(":"+httpAddr, handler); err != nil {


### PR DESCRIPTION
Update `NewStreamableHTTPHandler` to pass `&mcp.StreamableHTTPOptions{Stateless: true}` to enable the stateless 2026-07-28 protocol over HTTP transport.